### PR TITLE
Clean up ModernFamilyHeader date display

### DIFF
--- a/components/family/ModernFamilyHeader.tsx
+++ b/components/family/ModernFamilyHeader.tsx
@@ -194,22 +194,11 @@ export function ModernFamilyHeader({
           {/* Info Row */}
           <div className="flex flex-col sm:flex-row sm:items-center gap-4 text-white/90">
             <span className={cn(
-              "font-medium",
-              touchMode ? "text-lg" : "text-sm md:text-base"
-            )}>
-              {date}
-            </span>
-            
-            <span className="hidden sm:inline text-white/60">•</span>
-            
-            <span className={cn(
               "text-blue-200 font-medium",
               touchMode ? "text-lg" : "text-sm md:text-base"
             )}>
               {currentMessage}
             </span>
-            
-
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove redundant date display from ModernFamilyHeader info row
- Keep only the current message for cleaner UI
- Simplify layout by removing unnecessary separator

## Test plan
- [x] Verify header displays correctly without date
- [x] Confirm current message still shows properly
- [x] Check responsive behavior on mobile and desktop

🤖 Generated with [Claude Code](https://claude.ai/code)